### PR TITLE
relevant field only

### DIFF
--- a/src/main/java/life/tannineo/cs7is3/group4/App.java
+++ b/src/main/java/life/tannineo/cs7is3/group4/App.java
@@ -121,11 +121,12 @@ public class App {
 //            System.out.println(documentQuery.narrative);
 //        }
         LinkedHashMap<String, Query> queryLinkedHashMap = new LinkedHashMap<>();
-        MultiFieldQueryParser multiFieldQueryParser = new MultiFieldQueryParser(FieldName.getAllNames(), myAnalyzer);
+		String[] relevantFields = {"TEXT"};
+        MultiFieldQueryParser multiFieldQueryParser = new MultiFieldQueryParser(relevantFields, myAnalyzer);
         // multiFieldQueryParser.setAllowLeadingWildcard(true);
         for (DocumentQuery dq : documentQueries) {
             System.out.println("Parsing Query ID:" + dq.queryId);
-            String parsedQueryStr = dq.title + " " + dq.description + " " + dq.narrative;
+            String parsedQueryStr = dq.description;
 //            String parsedQueryStr = MyQueryStringParser.parseQueryString(myAnalyzer, dq.title + " " + dq.description + " " + dq.narrative);
             System.out.println(parsedQueryStr);
             Query qry = multiFieldQueryParser.parse(parsedQueryStr);


### PR DESCRIPTION
First change is to supply the multiFieldQueryParser with an array of relevant fields as some fields will not contribute whatsoever. Currently only TEXT as that's the most important field.

Second - only use the description. The narrative field often is of the form 'x is not relevant' - which hurts the search if it is included. Title seems to not contribute (at least on the test qrel).

These two boost the MAP from 17 to 25.